### PR TITLE
Update libexiv2 to current stable branch and gexiv2 to 0.10.10

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -124,7 +124,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gexiv2.git/",
-                    "commit" : "4cb516eb6550b3671642adece7ef6266dfcffa6d"
+                    "commit" : "e3046adf3029db6dd6f3dc7edab30b18ff7d7014"
                 }
             ]
         },

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -106,7 +106,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/Exiv2/exiv2/",
-                    "commit" : "e7ffd83af29187190da7f98dcbca8a4d70e19582"
+                    "commit" : "2b59f5be328ba1972c0c62f4e3cd3b7b46733b5f"
                 }
             ]
         },

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -101,7 +101,12 @@
         {
             "name": "exiv2",
             "cleanup": [ "/bin" ],
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
+            "config-opts" : [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",
+                "-DEXIV2_BUILD_SAMPLES=OFF"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
gexiv2 update is necessary for being able to compile against exiv2 0.27