### PR TITLE
Update libraw to 0.19.2

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -141,15 +141,11 @@
                 {
                     "type": "archive",
                     "url" : "https://www.libraw.org/data/LibRaw-0.19.2.tar.gz",
-                    "sha256" : "63a0a7088206f4083039c8a6bcacdfd0d739854205c4821475e314821d13bddb"
+                    "sha256" : "400d47969292291d297873a06fb0535ccce70728117463927ddd9452aa849644"
                 },
                 {
                     "type": "patch",
                     "path": "libraw-pkgconfig.patch"
-                },
-                {
-                    "type": "shell",
-                    "commands": [ "autoreconf --force --install --verbose" ]
                 }
             ]
         },

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -140,12 +140,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url" : "https://www.libraw.org/data/LibRaw-0.19.1.tar.gz",
-                    "sha256" : "a21019db16d87accbb8660056365ab09a204475c77c97b86c922bb972ce15ef6"
+                    "url" : "https://www.libraw.org/data/LibRaw-0.19.2.tar.gz",
+                    "sha256" : "63a0a7088206f4083039c8a6bcacdfd0d739854205c4821475e314821d13bddb"
                 },
                 {
                     "type": "patch",
                     "path": "libraw-pkgconfig.patch"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf --force --install --verbose" ]
                 }
             ]
         },


### PR DESCRIPTION
    Fixed possible buffer overrun at Fuji makernotes parser
    Fixed possible write to NULL pointer at raw2image/raw2image_ex calls.
    Details:
        Three different CVE numbers was assigned for single problem: CVE-2018-20363, CVE-2018-20364, CVE-2018-20365