### PR TITLE
Update download URL of libgphoto2

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -68,7 +68,7 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://datapacket.dl.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
+                    "url" : "https://downloads.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
                     "sha256" : "d8af23364aa40fd8607f7e073df74e7ace05582f4ba13f1724d12d3c97e8852d"
                 }
             ],


### PR DESCRIPTION
The previous URL doesn't work, this one does. I wonder if this is a temporary or permanent change in the Sourceforge side.