### PR TITLE
Update Shotwell to 0.30.18

### DIFF
--- a/0001-gphoto2-Add-missing-cheader-attributes-of-delegate-s.patch
+++ b/0001-gphoto2-Add-missing-cheader-attributes-of-delegate-s.patch
@@ -1,0 +1,57 @@
+From 1c8760ed76407ecb6e29ce0b8e1093ad7a0a8f58 Mon Sep 17 00:00:00 2001
+From: Rico Tzschichholz <ricotz@ubuntu.com>
+Date: Sun, 5 Feb 2023 20:44:49 +0100
+Subject: [PATCH] gphoto2: Add missing cheader attributes of delegate symbols
+
+---
+ vapi/libgphoto2.vapi | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/vapi/libgphoto2.vapi b/vapi/libgphoto2.vapi
+index 34fc1c49..8509cdb5 100644
+--- a/vapi/libgphoto2.vapi
++++ b/vapi/libgphoto2.vapi
+@@ -340,19 +340,40 @@ namespace GPhoto {
+         public void set_message_func([CCode (delegate_target_pos=3.1)] ContextMessageFunc messageFunc);
+     }
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextIdleFunc(Context context);
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextErrorFunc(Context context, string text);
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextStatusFunc(Context context, string text);
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextMessageFunc(Context context, string text);
+     
+     // TODO: Support for va_args in Vala, esp. for delegates?
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate uint ContextProgressStartFunc(Context context, float target, string text);
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextProgressUpdateFunc(Context context, uint id, float current);
+     
++    [CCode (
++        cheader_filename="gphoto2/gphoto2-context.h"
++    )]
+     public delegate void ContextProgressStopFunc(Context context, uint id);
+     
+     [CCode (
+-- 
+2.39.2
+

--- a/libraw-pkgconfig.patch
+++ b/libraw-pkgconfig.patch
@@ -1,6 +1,7 @@
---- LibRaw-0.20-Beta1/libraw.pc.in~	2020-05-13 14:22:12.656424311 +0200
-+++ LibRaw-0.20-Beta1/libraw.pc.in	2020-05-13 14:22:27.481441569 +0200
-@@ -5,7 +5,8 @@
+diff -r -u foo/libraw.pc.in libraw-7/libraw.pc.in
+--- foo/libraw.pc.in	2023-04-01 14:26:50.358780145 +0200
++++ libraw-7/libraw.pc.in	2023-01-05 07:49:26.000000000 +0100
+@@ -5,8 +5,8 @@
  
  Name: libraw
  Description: Raw image decoder library (non-thread-safe)
@@ -8,12 +9,14 @@
 +Requires.private: @PACKAGE_REQUIRES@
  Version: @PACKAGE_VERSION@
 -Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
+-Libs.private: @PACKAGE_LIBS_PRIVATE@
 +Libs: -L${libdir} -lraw@PC_OPENMP@
-+Libs.private: -lstdc++
++Libs.private: @PACKAGE_LIBS_PRIVATE@ -lstdc++
  Cflags: -I${includedir}/libraw -I${includedir}
---- LibRaw-0.20-Beta1/libraw_r.pc.in~	2020-05-13 14:22:18.034430572 +0200
-+++ LibRaw-0.20-Beta1/libraw_r.pc.in	2020-05-13 14:22:27.481441569 +0200
-@@ -5,7 +5,8 @@
+diff -r -u foo/libraw_r.pc.in libraw-7/libraw_r.pc.in
+--- foo/libraw_r.pc.in	2023-04-01 14:26:50.358780145 +0200
++++ libraw-7/libraw_r.pc.in	2023-01-05 07:49:26.000000000 +0100
+@@ -5,8 +5,8 @@
  
  Name: libraw
  Description: Raw image decoder library (thread-safe)
@@ -21,6 +24,7 @@
 +Requires.private: @PACKAGE_REQUIRES@
  Version: @PACKAGE_VERSION@
 -Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
+-Libs.private: @PACKAGE_LIBS_PRIVATE@
 +Libs: -L${libdir} -lraw_r@PC_OPENMP@
-+Libs.private: -lstdc++
++Libs.private: @PACKAGE_LIBS_PRIVATE@ -lstdc++
  Cflags: -I${includedir}/libraw -I${includedir}

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -113,7 +113,7 @@
             "name": "gexiv2",
             "buildsystem" : "meson",
             "cleanup" : ["/lib/girepository-1.0", "/share/gir-1.0"],
-            "config-opts" : ["-Dpython2_girdir=no", "-Dpython3_girdir=no"],
+            "config-opts" : ["-Dpython3_girdir=no"],
             "build-options" : {
                 "env": {
                     "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
@@ -135,8 +135,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url" : "https://www.libraw.org/data/LibRaw-0.20.2.tar.gz",
-                    "sha256" : "dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6"
+                    "url" : "https://www.libraw.org/data/LibRaw-0.21.1.tar.gz",
+                    "sha256" : "630a6bcf5e65d1b1b40cdb8608bdb922316759bfb981c65091fec8682d1543cd"
                 },
                 {
                     "type": "patch",
@@ -151,14 +151,38 @@
             ]
         },
         {
+            "name": "libportal",
+            "buildsystem": "meson",
+            "builddir": true,
+            "config-opts": [
+                "--libdir=/app/lib",
+                "--buildtype=debugoptimized",
+                "-Dbackends=gtk3",
+                "-Ddocs=false",
+                "-Dtests=false"
+            ],
+            "sources" : [
+                {
+                    "type": "git",
+                    "url": "https://github.com/flatpak/libportal.git",
+                    "branch": "main",
+                    "commit": "f84a5606f15dfff6771a12d2ce75699d2c7a3d8f"
+                }
+            ]
+        },
+        {
             "name": "shotwell",
             "buildsystem": "meson",
             "config-opts" : ["-Dudev=false", "-Dinstall-apport-hook=false", "-Dface-detection=false", "-Dfatal_warnings=false"],
             "sources" : [
                 {
                     "type": "archive",
-                    "url" : "https://download.gnome.org/sources/shotwell/0.30/shotwell-0.30.17.tar.xz",
-                    "sha256" : "b65a57dd0a1fc4f9ec70d4658f09320840b8aaa9f6e910c5b3fe960f5ec9cfc4"
+                    "url" : "https://download.gnome.org/sources/shotwell/0.30/shotwell-0.30.18.tar.xz",
+                    "sha256" : "a8c04a3c5cee0506fa103dde58ced15f03c6478f59958419d2a5f80761f14135"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "0001-gphoto2-Add-missing-cheader-attributes-of-delegate-s.patch"
                 }
             ],
             "post-install" : [


### PR DESCRIPTION
Adds libportal (required by Shotwell 0.30.18) and upgrades LibRaw to 0.21.1

Fixes #35 