### PR TITLE
Roll-back jpeg-xl to 0.8.2

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -285,15 +285,10 @@
             ],
             "sources": [
                 {
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 232764,
-                        "tag-template": "v$version"
-                    },
                     "type": "git",
                     "url": "https://github.com/libjxl/libjxl.git",
-                    "tag": "v0.9.1",
-                    "commit": "b8ceae3a6e9d0ffd9efebcbdd04322fcfc502eed"
+                    "tag": "v0.8.2",
+                    "commit": "954b460768c08a147abf47689ad69b0e7beff65e"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
0.9 seems to be crashy for some reason, needs further investigation