### PR TITLE
Move HEIC support to an extension

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -22,7 +22,7 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/pkconfig",
+        "/lib/pkgconfig",
         "/share/pkgconfig",
         "/share/gtk-doc",
         "/share/man",

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -32,6 +32,14 @@
         "*.la",
         "*.a"
     ],
+    "add-extensions": {
+        "org.gnome.Shotwell.HEIC": {
+            "directory": "lib/libheif",
+            "add-ld-path": "lib",
+            "bundle": true,
+            "autodelete": true
+        }
+    },
     "modules": [
         {
             "name": "libusb",
@@ -208,10 +216,15 @@
             "name": "de256",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_INSTALL_LIBDIR=lib",
+                "-DCMAKE_INSTALL_PREFIX=/app/lib/libheif",
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DENABLE_DECODER=Off",
                 "-DENABLE_ENCODER=OfF"
+            ],
+            "cleanup": [
+                "/lib/libheif/include",
+                "/lib/libheif/lib/cmake",
+                "/lib/libheif/lib/pkgconfig"
             ],
             "sources": [
                 {
@@ -232,7 +245,7 @@
             "config-opts": [
                 "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DWITH_LIBDE265=On",
+                "-DWITH_LIBDE265_PLUGIN=On",
                 "-DWITH_DAV1D=Off",
                 "-DWITH_AOM_ENCODER=Off",
                 "-DWITH_AOM_DECODER=Off",
@@ -241,6 +254,9 @@
                 "-DENABLE_PLUGIN_LOADING=On",
                 "-DWITH_EXAMPLES=Off"
             ],
+            "build-options": {
+                "append-pkg-config-path": "/app/lib/libheif/lib/pkgconfig"
+            },
             "sources": [
                 {
                     "x-checker-data": {

--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -22,6 +22,7 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/cmake",
         "/lib/pkgconfig",
         "/share/pkgconfig",
         "/share/gtk-doc",


### PR DESCRIPTION
HEIC is H.265-encoded image data in a HEIF container. H.265 is
patent-encumbered, and some distributors wish not to distribute H.265
decoders or encoders as a result.

libheif supports building some or all of its image-format backends as
dynamically-loaded plugins. Configure it to build the libde265 backend
as a plugin, installed to /app/lib/libheif; and then split
/app/lib/libheif into an extension. This extension,
org.gnome.Shotwell.HEIC, will by default be automatically installed and
removed together with the main app, including when existing
installations update to a build of org.gnome.Shotwell containing this
change. However, distributors and users can choose to use `flatpak mask`
to prevent this extension from being installed. In that case, other
image formats in HEIF containers, such as AVIF, will still be supported,
but attempting to read HEIC files will fail.

I also cleaned up some stray build files while I was here.