### PR TITLE
Enable udev in flatpak

### DIFF
--- a/org.gnome.Shotwell.json
+++ b/org.gnome.Shotwell.json
@@ -54,16 +54,12 @@
                     "url": "https://github.com/libusb/libusb/archive/v1.0.27.tar.gz",
                     "sha256": "e8f18a7a36ecbb11fb820bd71540350d8f61bcd9db0d2e8c18a6fb80b214a3de"
                 }
-            ],
-            "config-opts": [
-                "--disable-udev"
             ]
         },
         {
             "name": "libghoto2",
             "cleanup": [
                 "/bin",
-                "/lib/udev",
                 "/share/doc"
             ],
             "sources": [
@@ -329,7 +325,6 @@
             "name": "shotwell",
             "buildsystem": "meson",
             "config-opts": [
-                "-Dudev=false",
                 "-Dinstall_apport_hook=false",
                 "-Dfatal_warnings=false",
                 "-Dface_detection_helper_bus=private",


### PR DESCRIPTION
Newer runtimes have udev, and for some reason at some point the whole mechanics in gphoto? changed such that the periodic rescanning would take ages in libusb without it.

With udev, everything is now smooth.